### PR TITLE
Fix normative refs

### DIFF
--- a/draft-ietf-alto-oam-yang.md
+++ b/draft-ietf-alto-oam-yang.md
@@ -88,25 +88,26 @@ normative:
   RFC8686:
   RFC8895:
   RFC8896:
-informative:
-  RFC2622:
   RFC6241:
-  RFC7921:
-  RFC7971:
-  RFC8341:
-  RFC8342:
-  RFC8346:
   RFC8040:
-  RFC8641:
-  RFC9240:
-  RFC9241:
-  RFC9275:
-  I-D.ietf-alto-performance-metrics:
+  RFC8341:
   I-D.ietf-netconf-tcp-client-server:
   I-D.ietf-netconf-tls-client-server:
   I-D.ietf-netconf-http-client-server:
   I-D.ietf-netconf-netconf-client-server:
   I-D.ietf-netconf-restconf-client-server:
+informative:
+  RFC2622:
+  RFC7921:
+  RFC7971:
+  RFC8342:
+  RFC8346:
+  RFC8641:
+  RFC9240:
+  RFC9241:
+  RFC9275:
+  I-D.ietf-alto-performance-metrics:
+
 
 --- abstract
 


### PR DESCRIPTION
At least the following have to be listed as normative.  Please double check other entries. If you have doubts, please let me know.

```
   [I-D.ietf-netconf-http-client-server]
              Watsen, K., "YANG Groupings for HTTP Clients and HTTP
              Servers", Work in Progress, Internet-Draft, draft-ietf-
              netconf-http-client-server-12, 12 December 2022,
              <https://datatracker.ietf.org/doc/html/draft-ietf-netconf-
              http-client-server-12>.

   [I-D.ietf-netconf-netconf-client-server]
              Watsen, K., "NETCONF Client and Server Models", Work in
              Progress, Internet-Draft, draft-ietf-netconf-netconf-
              client-server-28, 12 December 2022,
              <https://datatracker.ietf.org/doc/html/draft-ietf-netconf-
              netconf-client-server-28>.

   [I-D.ietf-netconf-restconf-client-server]
              Watsen, K., "RESTCONF Client and Server Models", Work in
              Progress, Internet-Draft, draft-ietf-netconf-restconf-
              client-server-28, 12 December 2022,
              <https://datatracker.ietf.org/doc/html/draft-ietf-netconf-
              restconf-client-server-28>.

   [I-D.ietf-netconf-tcp-client-server]
              Watsen, K. and M. Scharf, "YANG Groupings for TCP Clients
              and TCP Servers", Work in Progress, Internet-Draft, draft-
              ietf-netconf-tcp-client-server-15, 12 December 2022,
              <https://datatracker.ietf.org/doc/html/draft-ietf-netconf-
              tcp-client-server-15>.

   [I-D.ietf-netconf-tls-client-server]
              Watsen, K., "YANG Groupings for TLS Clients and TLS
              Servers", Work in Progress, Internet-Draft, draft-ietf-
              netconf-tls-client-server-32, 12 December 2022,
              <https://datatracker.ietf.org/doc/html/draft-ietf-netconf-
              tls-client-server-32>.

   [RFC6241]  Enns, R., Ed., Bjorklund, M., Ed., Schoenwaelder, J., Ed.,
              and A. Bierman, Ed., "Network Configuration Protocol
              (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
              <https://www.rfc-editor.org/rfc/rfc6241>.

   [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
              Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
              <https://www.rfc-editor.org/rfc/rfc8040>.

   [RFC8341]  Bierman, A. and M. Bjorklund, "Network Configuration
              Access Control Model", STD 91, RFC 8341,
              DOI 10.17487/RFC8341, March 2018,
              <https://www.rfc-editor.org/rfc/rfc8341>.
```