### PR TITLE
Some terms do not need to be expanded

### DIFF
--- a/term.md
+++ b/term.md
@@ -14,14 +14,8 @@ DNS:
 HTTP:
   : Hypertext Transfer Protocol
 
-IP:
-  : Internet Protocol
-
 IRR:
   : Internet Routing Registry
-
-NAPTR:
-  : Naming Authority Pointer
 
 OAM:
   : Operations, Administration, and Maintenance (Section 3 of {{?RFC6291}})
@@ -43,9 +37,6 @@ TLS:
 
 URI:
   : Uniform Resource Identifier
-
-YANG:
-  : Yet Another Next Generation
 
 ## Tree Diagrams
 


### PR DESCRIPTION
Please refer to https://www.rfc-editor.org/materials/abbrev.expansion.txt. It says specifically: 

"Names of resource records do not need to be expanded (e.g., NAPTR)."