### PR TITLE
8340 should be listed as informative.

### DIFF
--- a/term.md
+++ b/term.md
@@ -41,7 +41,7 @@ URI:
 ## Tree Diagrams
 
 The meaning of the symbols in the tree diagrams is defined in
-{{RFC8340}}.
+{{?RFC8340}}.
 
 ## Prefixes in Data Node Names
 


### PR DESCRIPTION
This is listed by few as normative, but the wide practice is to list this one as informative: Please check https://datatracker.ietf.org/doc/rfc8340/referencedby/