### PR TITLE
Change augmented choice/case to container

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -6,7 +6,7 @@ model can be augmented:
 
 - The `server-discovery-manner` choice of the `server-discovery`.
 - The `authentication` choice of each `auth-client`.
-- The `data-source` choice.
+- The `data-source` node.
 - The `algorithm` choice of the `resource-params` of each `resource`.
 
 ## An Example Module for Extended Server Discovery Manners {#example-server-disc}

--- a/design.md
+++ b/design.md
@@ -220,7 +220,7 @@ module: ietf-alto
         +--rw data-source* [source-id]
         |  +--rw source-id                    source-id
         |  +--rw source-type                  identityref
-        |  +--rw (source-params)?
+        |  +--rw source-params?
         ...
 ~~~
 {: #tree-data-src title='IETF ALTO Server Data Source Subtree Structure' artwork-align="center"}

--- a/design.md
+++ b/design.md
@@ -220,7 +220,7 @@ module: ietf-alto
         +--rw data-source* [source-id]
         |  +--rw source-id                    source-id
         |  +--rw source-type                  identityref
-        |  +--rw source-params?
+        |  +--rw source-params
         ...
 ~~~
 {: #tree-data-src title='IETF ALTO Server Data Source Subtree Structure' artwork-align="center"}

--- a/yang/example-alto-alg.yang
+++ b/yang/example-alto-alg.yang
@@ -74,6 +74,7 @@ module example-alto-alg {
               path '/alto:alto/alto:alto-server/alto:data-source'
                  + '[alto:source-id'
                  + ' = current()/../source-datastore]'
+                 + '/alto:source-params'
                  + '/example-alto-ds:yang-datastore-source-params'
                  + '/example-alto-ds:target-paths/example-alto-ds:name';
             }

--- a/yang/example-alto-data-source.yang
+++ b/yang/example-alto-data-source.yang
@@ -83,58 +83,54 @@ module example-alto-data-source {
 
   augment "/alto:alto/alto:alto-server/alto:data-source"
         + "/alto:source-params" {
+    when 'derived-from-or-self(../alto:source-type,'
+       + '"yang-datastore")';
     description
-      "Example of data source for YANG datastore.";
-    case yang-datastore {
-      when 'derived-from-or-self(alto:source-type,'
-         + '"yang-datastore")';
+      "Example data source for local or remote YANG datastore.";
+    container yang-datastore-source-params {
       description
-        "Example data source for local or remote YANG datastore.";
-      container yang-datastore-source-params {
+        "YANG datastore specific configuration.";
+      leaf datastore {
+        type ds:datastore-ref;
+        mandatory true;
         description
-          "YANG datastore specific configuration.";
-        leaf datastore {
-          type ds:datastore-ref;
-          mandatory true;
+          "Reference of the datastore from which to get data.";
+      }
+      list target-paths {
+        key name;
+        description
+          "XML Path Language (XPath) to subscribed YANG datastore
+           node or subtree.";
+        leaf name {
+          type string;
           description
-            "Reference of the datastore from which to get data.";
+            "Name of the supported XPath or subtree filters.";
         }
-        list target-paths {
-          key name;
-          description
-            "XML Path Language (XPath) to subscribed YANG datastore
-             node or subtree.";
-          leaf name {
-            type string;
-            description
-              "Name of the supported XPath or subtree filters.";
-          }
-          uses yp:selection-filter-types;
+        uses yp:selection-filter-types;
+      }
+      leaf protocol {
+        type identityref {
+          base protocol-type;
         }
-        leaf protocol {
-          type identityref {
-            base protocol-type;
-          }
-          description
-            "Indicates the protocol that is used to access the YANG
-             datastore.";
+        description
+          "Indicates the protocol that is used to access the YANG
+           datastore.";
+      }
+      container restconf {
+        uses rcc:restconf-client-app-grouping {
+          when 'derived-from-or-self(../protocol, "restconf")';
         }
-        container restconf {
-          uses rcc:restconf-client-app-grouping {
-            when 'derived-from-or-self(../protocol, "restconf")';
-          }
-          description
-            "Parameters for the RESTCONF endpoint of the YANG
-             datastore.";
+        description
+          "Parameters for the RESTCONF endpoint of the YANG
+           datastore.";
+      }
+      container netconf {
+        uses ncc:netconf-client-app-grouping {
+          when 'derived-from-or-self(../protocol, "netconf")';
         }
-        container netconf {
-          uses ncc:netconf-client-app-grouping {
-            when 'derived-from-or-self(../protocol, "netconf")';
-          }
-          description
-            "Parameters for the NETCONF endpoint of the YANG
-             datastore.";
-        }
+        description
+          "Parameters for the NETCONF endpoint of the YANG
+           datastore.";
       }
     }
   }

--- a/yang/ietf-alto.yang
+++ b/yang/ietf-alto.yang
@@ -1061,7 +1061,7 @@ module ietf-alto {
           description
             "Identify the type of the data source.";
         }
-        choice source-params {
+        container source-params {
           description
             "Data source specific configuration.";
           reference


### PR DESCRIPTION
In practice, choice-case-when is redundant. And simply using augment-when container can better support polymorphsim.

Close #85.