### PR TITLE
Fixed path to reference yang node

### DIFF
--- a/yang/example-alto-alg.yang
+++ b/yang/example-alto-alg.yang
@@ -57,7 +57,8 @@ module example-alto-alg {
         container l3-unicast-topo {
           leaf source-datastore {
             type alto:data-source-ref;
-            must 'deref(.)/../ex-alto-ds:yang-datastore-source-params'
+            must 'deref(.)/../alto:source-params'
+               + '/ex-alto-ds:yang-datastore-source-params'
                + '/ex-alto-ds:datastore '
                + '= "ietf-datastores:operational"'
                {

--- a/yang/example-alto-config.json
+++ b/yang/example-alto-config.json
@@ -60,36 +60,37 @@
         {
           "source-id": "test-yang-ds",
           "source-type": "example-alto-data-source:yang-datastore",
-          "feed-interval": 30,
-          "example-alto-data-source:yang-datastore-source-params": {
-            "datastore": "ietf-datastores:operational",
-            "target-paths": [
-              {
-                "name": "network-topology",
-                "datastore-xpath-filter": "/network-topology:network-topology/topology[topology-id=bgp-example-ipv4-topology]"
-              }
-            ],
-            "protocol": "restconf",
-            "restconf": {
-              "listen": {
-                "endpoint": [
-                  {
-                    "name": "example restconf server",
-                    "https": {
-                      "tcp-server-parameters": {
-                        "local-address": "172.17.0.2"
-                      },
-                      "http-client-parameters": {
-                        "client-identity": {
-                          "basic": {
-                            "user-id": "carol",
-                            "cleartext-password": "secret"
+          "source-params": {
+            "example-alto-data-source:yang-datastore-source-params": {
+              "datastore": "ietf-datastores:operational",
+              "target-paths": [
+                {
+                  "name": "network-topology",
+                  "datastore-xpath-filter": "/network-topology:network-topology/topology[topology-id=bgp-example-ipv4-topology]"
+                }
+              ],
+              "protocol": "restconf",
+              "restconf": {
+                "listen": {
+                  "endpoint": [
+                    {
+                      "name": "example restconf server",
+                      "https": {
+                        "tcp-server-parameters": {
+                          "local-address": "172.17.0.2"
+                        },
+                        "http-client-parameters": {
+                          "client-identity": {
+                            "basic": {
+                              "user-id": "carol",
+                              "cleartext-password": "secret"
+                            }
                           }
                         }
                       }
                     }
-                  }
-                ]
+                  ]
+                }
               }
             }
           }


### PR DESCRIPTION
Fixed path in `example-alto-alg.yang` and the related JSON example in `example-alto-config.json` to align with the updated `example-alto-data-source.json`.